### PR TITLE
Update handling for EOF,ErrClosedPipe to hard return

### DIFF
--- a/apt/message_reader.go
+++ b/apt/message_reader.go
@@ -44,11 +44,7 @@ func (r *AptMessageReader) ReadMessage(ctx context.Context) (*AptMessage, error)
 		}
 		line, err := r.reader.ReadString('\n')
 		if err != nil {
-			/*
-				if err == io.EOF || err == io.ErrClosedPipe {
-					// TODO: what to return in this case?
-				}
-			*/
+			// io.EOF, io.ErrClosedPipe, etc. should be handled by callers
 			return nil, err
 		}
 

--- a/apt/method.go
+++ b/apt/method.go
@@ -80,6 +80,9 @@ func (m *AptMethod) Run(ctx context.Context) {
 		}
 		msg, err := m.reader.ReadMessage(ctx)
 		if err != nil {
+			if err == io.EOF || err == io.ErrClosedPipe {
+				return
+			}
 			continue
 		}
 		switch msg.code {

--- a/apt/method_test.go
+++ b/apt/method_test.go
@@ -336,7 +336,7 @@ func TestAptMethodRunReaderErrClosedPipe(t *testing.T) {
 	defer cancel()
 	go workMethod.Run(ctx2)
 
-	// Close the read buffer to replicate force an io.ErrClosedPipe.
+	// Close the read buffer to force an io.ErrClosedPipe.
 	if err := stdoutreader.Close(); err != nil {
 		t.Fatalf("failed to close read buffer, %v", err)
 	}


### PR DESCRIPTION
After looking at cloudflare's apt-transport that behaves very similarly it seems like a hard return is the right way to handle `EOF` and `ErrClosedPipe` errors coming from the reader.

See here: https://github.com/cloudflare/apt-transport-cloudflared/blob/8fd3a7c4318a39b24d08b0fb62ed9983e1558aea/apt/method.go#L82-L85

Somewhat related; I needed this change plus a different binary name (see [here](https://github.com/GoogleCloudPlatform/artifact-registry-apt-transport/issues/8)) to get this transport to work under reprepro.