### PR TITLE
Access token support

### DIFF
--- a/90artifact-registry
+++ b/90artifact-registry
@@ -9,4 +9,9 @@ Acquire::gar {
     # Use Service-Account-Email to specify a service account to use on Google
     # Compute Engine.
     #Service-Account-Email "my-service-account@some-domain.com";
+    #
+    # Use Access-Token-ENV to specify an environment variable to use as an
+    # access token. This is useful for CI/CD systems that provide an access
+    # token as an environment variable.
+    #Access-Token-ENV "CLOUDSDK_AUTH_ACCESS_TOKEN"
 };

--- a/apt/method.go
+++ b/apt/method.go
@@ -66,7 +66,7 @@ type AptMethod struct {
 }
 
 type aptMethodConfig struct {
-	serviceAccountJSON, serviceAccountEmail string
+	serviceAccountJSON, serviceAccountEmail, accessTokenENV string
 }
 
 // Run runs the method.
@@ -236,6 +236,14 @@ func (m *AptMethod) handleConfigure(msg *AptMessage) {
 				return
 			}
 			m.config.serviceAccountEmail = strings.TrimSpace(parts[1])
+		}
+		if strings.Contains(configItem, "Acquire::gar::Access-Token-ENV") {
+			parts := strings.SplitN(configItem, "=", 2)
+			if len(parts) != 2 {
+				// TODO: log this?
+				return
+			}
+			m.config.accessTokenENV = strings.TrimSpace(parts[1])
 		}
 	}
 	// Enforce the precedence of these two options.

--- a/apt/method.go
+++ b/apt/method.go
@@ -114,6 +114,12 @@ func (m *AptMethod) initClient() error {
 		ts = creds.TokenSource
 	case m.config.serviceAccountEmail != "":
 		ts = google.ComputeTokenSource(m.config.serviceAccountEmail)
+	case m.config.accessTokenENV != "":
+		accessToken := os.Getenv(m.config.accessTokenENV)
+		if accessToken == "" {
+			return fmt.Errorf("Failed to obtain token from environment variable: %s", m.config.accessTokenENV)
+		}
+		ts = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	default:
 		creds, err := google.FindDefaultCredentials(ctx)
 		if err != nil {


### PR DESCRIPTION
# Background
In addition JSON service account credentials, it is sometimes advantageous to using short-lived OAuth2 access tokens to retrieve packages from the artifact registry, for example, in a docker build where writing long-lived service account keys could risk being exported in the image.

# Changes
- Adds a configuration file parameter Access-Token-ENV which specifies an environment variable, such as CLOUDSDK_AUTH_ACCESS_TOKEN, that holds an access token.
- After checking for JSON service account credentials and service account emails for the metadata service, we check for an access token environment variable and create the appropriate static token source.