### PR TITLE
Make behave more like built-in transports

### DIFF
--- a/apt/message_reader.go
+++ b/apt/message_reader.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 )
 
+var ErrEmptyMessage = errors.New("empty message")
+
 // MessageReader supports reading Apt messages.
 type MessageReader struct {
 	reader  *bufio.Reader
@@ -44,18 +46,13 @@ func (r *MessageReader) ReadMessage(ctx context.Context) (*Message, error) {
 		}
 		line, err := r.reader.ReadString('\n')
 		if err != nil {
-			/*
-				if err == io.EOF || err == io.ErrClosedPipe {
-					// TODO: what to return in this case?
-				}
-			*/
 			return nil, err
 		}
 
 		line = strings.TrimSpace(line)
 		if line == "" {
 			if r.message == nil {
-				return nil, errors.New("empty message")
+				return nil, ErrEmptyMessage
 			}
 
 			// Message is done, return and reset.

--- a/apt/method_test.go
+++ b/apt/method_test.go
@@ -52,6 +52,30 @@ func TestHandleConfigure(t *testing.T) {
 			},
 			aptMethodConfig{debug: true},
 		},
+		{
+			[]string{
+				"Debug::Acquire::gar=enable",
+			},
+			aptMethodConfig{debug: true},
+		},
+		{
+			[]string{
+				"Debug::Acquire::gar=10",
+			},
+			aptMethodConfig{debug: false},
+		},
+		{
+			[]string{
+				"Debug::Acquire::gar=0",
+			},
+			aptMethodConfig{debug: false},
+		},
+		{
+			[]string{
+				"Debug::Acquire::gar=-1",
+			},
+			aptMethodConfig{debug: false},
+		},
 	}
 
 	for _, tt := range tests {

--- a/apt/method_test.go
+++ b/apt/method_test.go
@@ -46,6 +46,12 @@ func TestHandleConfigure(t *testing.T) {
 			},
 			aptMethodConfig{},
 		},
+		{
+			[]string{
+				"Debug::Acquire::gar=1",
+			},
+			aptMethodConfig{debug: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -258,7 +264,10 @@ func TestAptMethodRunFail(t *testing.T) {
 	ctx := context.Background()
 	ctx2, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go workMethod.Run(ctx2)
+	errChan := make(chan error)
+	go func() {
+		errChan <- workMethod.Run(ctx2)
+	}()
 
 	reader := MessageReader{reader: bufio.NewReader(stdoutreader)}
 	msg, err := reader.ReadMessage(ctx)
@@ -272,17 +281,18 @@ func TestAptMethodRunFail(t *testing.T) {
 	writer := MessageWriter{writer: stdinwriter}
 	writer.WriteMessage(Message{
 		code:        700,
-		description: "Bogus method",
+		description: "Malformed message",
+		fields:      map[string][]string{"": {"foo"}},
 	})
 
-	msg, err = reader.ReadMessage(ctx)
-	if err != nil {
-		t.Fatalf("failed, %v", err)
+	// If we receive a malformed message from `apt`, we immediately bail
+	// without sending an error response. Unlike the other tests, there is no
+	// protocol message to read here, but we can assert on the return value of
+	// `Run`.
+	runErr := <-errChan
+	if runErr == nil {
+		t.Fatalf("failed, expected non-nil runErr (empty key)")
 	}
-	if msg.code != 401 || msg.description != "General Failure" || msg.Get("Message") == "" {
-		t.Errorf("failed, didn't receive general failure message. msg is %q", msg)
-	}
-	cancel()
 
 	for _, p := range []io.Closer{stdinreader, stdinwriter, stdoutreader, stdoutwriter} {
 		if err := p.Close(); err != nil {

--- a/apt/method_test.go
+++ b/apt/method_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -316,6 +317,9 @@ func TestAptMethodRunFail(t *testing.T) {
 	runErr := <-errChan
 	if runErr == nil {
 		t.Fatalf("failed, expected non-nil runErr (empty key)")
+	}
+	if !strings.Contains(runErr.Error(), "malformed") {
+		t.Fatalf("failed, expected runErr to contain 'malformed'")
 	}
 
 	for _, p := range []io.Closer{stdinreader, stdinwriter, stdoutreader, stdoutwriter} {

--- a/cmd/ar+https/main.go
+++ b/cmd/ar+https/main.go
@@ -17,8 +17,8 @@ package main
 import (
 	"bufio"
 	"context"
-	"os"
 	"fmt"
+	"os"
 
 	"github.com/GoogleCloudPlatform/artifact-registry-apt-transport/apt"
 )

--- a/cmd/ar+https/main.go
+++ b/cmd/ar+https/main.go
@@ -18,11 +18,16 @@ import (
 	"bufio"
 	"context"
 	"os"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/artifact-registry-apt-transport/apt"
 )
 
 func main() {
 	apt := apt.NewAptMethod(bufio.NewReader(os.Stdin), os.Stdout)
-	apt.Run(context.Background())
+	err := apt.Run(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(100)
+	}
 }


### PR DESCRIPTION
I haven't found documentation on the apt transport protocol, so I'm just going by observed behavior of the built-in transports.

Make the following changes:

* Exit clean on EOF instead of running forever
* On malformed message, exit 100 without a protocol response
* Ignore unhandled message codes
* Like other transports, support a debug mode `Debug::Acquire::gar`

The http transport seems to consider an empty message an error, but given this case was already being handled specifically, I left it in.
