### PR TITLE
Provde the expected AR scopre for default credential lookup

### DIFF
--- a/apt/method.go
+++ b/apt/method.go
@@ -120,7 +120,7 @@ func (m *Method) initClient(ctx context.Context) error {
 	case m.config.serviceAccountEmail != "":
 		ts = google.ComputeTokenSource(m.config.serviceAccountEmail)
 	default:
-		creds, err := google.FindDefaultCredentials(ctx)
+		creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
 		if err != nil {
 			return fmt.Errorf("failed to obtain default creds: %v", err)
 		}


### PR DESCRIPTION
In case that apt is not sending over a `Config-Item` like `Acquire::gar::Service-Account-JSON`, the code falls back to default credential lookup.

If it finds a metadata service, then it will automatically inherit the default `cloud-plaform` scope, but if it fins a service account json over the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, no scope will be requested, therefore always add the required AR scope explicitly.

This fixes errors like

```
oauth2: cannot fetch token: 400 Bad Request
```

if the service account json is detected over the default credential lookup paths.