### PR TITLE
fix: `apt update` stuck when fields contain trailing \n

### DIFF
--- a/apt/message.go
+++ b/apt/message.go
@@ -16,9 +16,12 @@ package apt
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+var newlineRegexp = regexp.MustCompile(`\r?\n`)
 
 // Message represents a single RFC822 Apt message.
 type Message struct {
@@ -50,6 +53,11 @@ func (m *Message) String() string {
 	message := []string{fmt.Sprintf("%d %s", m.code, m.description)}
 	for _, key := range sortedKeys {
 		for _, val := range m.fields[key] {
+			// Messages are allowed to contain newlines, but they must not contain double newlines,
+			// nor end in a newline (since this would result in a premature double newline). We'll
+			// encode all newlines here as \n for simplicity.
+			val = newlineRegexp.ReplaceAllString(val, "\\n")
+
 			message = append(message, fmt.Sprintf("%s: %s", key, val))
 		}
 	}

--- a/apt/message.go
+++ b/apt/message.go
@@ -55,8 +55,8 @@ func (m *Message) String() string {
 		for _, val := range m.fields[key] {
 			// Messages are allowed to contain newlines, but they must not contain double newlines,
 			// nor end in a newline (since this would result in a premature double newline). We'll
-			// encode all newlines here as \n for simplicity.
-			val = newlineRegexp.ReplaceAllString(val, "\\n")
+			// encode all newlines here as a space instead for simplicity.
+			val = newlineRegexp.ReplaceAllString(val, " ")
 
 			message = append(message, fmt.Sprintf("%s: %s", key, val))
 		}

--- a/apt/message_test.go
+++ b/apt/message_test.go
@@ -107,6 +107,17 @@ func TestAptWriterWriteMessage(t *testing.T) {
 			},
 			"123 Fake\n\n",
 		},
+		{
+			Message{
+				code:        123,
+				description: "Fake",
+				fields: map[string][]string{
+					"akey": {"val ending with newline\n"},
+					"zkey": {"val containing \n\n double newlines"},
+				},
+			},
+			"123 Fake\nakey: val ending with newline\\n\nzkey: val containing \\n\\n double newlines\n\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/apt/message_test.go
+++ b/apt/message_test.go
@@ -116,7 +116,7 @@ func TestAptWriterWriteMessage(t *testing.T) {
 					"zkey": {"val containing \n\n double newlines"},
 				},
 			},
-			"123 Fake\nakey: val ending with newline\\n\nzkey: val containing \\n\\n double newlines\n\n",
+			"123 Fake\nakey: val ending with newline \nzkey: val containing    double newlines\n\n",
 		},
 	}
 


### PR DESCRIPTION
Before this commit, there were a few scenarios where this apt transport would format a message containing a field that had a trailing newline, which resulted in a message looking like:

```
400 URI Failure
Message: Get "https://us-central1-apt.pkg.dev/projects/<redacted>/dists/<redacted>/InRelease": oauth2/google: status code 503: {
  "error": {
  "code": 503,
  "message": "Authentication backend unavailable.",
  "status": "UNAVAILABLE"
  }
}

URI: ar+https://us-central1-apt.pkg.dev/projects/<redacted>/dists/<redacted>/InRelease'
```

As the above indicates, this can happen when this apt transport encounters an error when doing the underlying oauth2 token exchange; it directly puts the error message into the response on L199:

https://github.com/GoogleCloudPlatform/artifact-registry-apt-transport/blob/main/apt/method.go#L190-L201

Unfortunately, this causes apt update to treat this response as two separate messages, and since the first message does not contain a URI, it also doesn't realize that the InRelease fetch failed. This causes apt to hang indefinitely.

Here are a snippet of some logs that demonstrate this:

```
1712435831 2494987  <- ar+https:400%20URI%20Failure%0aMessage:%20Get%20"https://us-central1-apt.pkg.dev/projects/<redacted>/dists/<redacted>/InRelease":%20oauth2/google:%20status%20code%20503:%20{%0a%20%20"error":%20{%0a%20%20%20%20"code":%20503,%0a%20%20%20%20"message":%20"Authentication%20backend%20unavailable.",%0a%20%20%20%20"status":%20"UNAVAILABLE"%0a%20%20}%0a}
1712435831 2494987  <- ar+https:URI:%20ar+https://us-central1-apt.pkg.dev/projects/<redacted>/dists/etsy-ubuntu-jammy/InRelease
1712435831 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435831 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435832 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435832 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435833 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435833 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435834 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435834 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435835 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435835 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
1712435836 2494987 [0.000] Bytes: 0  / 1  # Files: 24 / 28
...
```

In the above log, each `<-` is a message received by apt. It thinks it received two separate messages, cannot match them to any download, and waits forever.

After this commit, the message struct encodes newlines as literal "\n" characters, so it prevents both trailing newlines and any accidental double newlines in the response.